### PR TITLE
fix: use correct resource arn for FSx file systems

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -186,7 +186,7 @@ data "aws_iam_policy_document" "lambda_policy" {
       ]
       resources = [
         for resource in var.resource_composition :
-        "arn:aws:fsx:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:db:${resource.params["id"]}"
+        "arn:aws:fsx:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:file-system/${resource.params["id"]}"
         if resource.type == "fsx_windows_file_system"
       ]
     }


### PR DESCRIPTION
Fixes the ARN used for FSx file systems. Previous one was copied from the RDS entry and not modified correctly.