### PR TITLE
fix: updates for downtime windows that go past midnight

### DIFF
--- a/scheduler/scheduler/cron_helper.py
+++ b/scheduler/scheduler/cron_helper.py
@@ -73,10 +73,15 @@ def extend_windows(
         date_composition_start_comp = int(date_composition_start.strftime('%H%M'))
         date_composition_stop_comp = int(date_composition_stop.strftime('%H%M'))
 
-        if extended_start_comp >= date_composition_start_comp and extended_start_comp < date_composition_stop_comp:
-            skip_start = True
+        def _within_operational_hours(value: int) -> bool:
+            # Operational window may wrap past midnight (e.g. 22:30->17:00 UTC when the
+            # schedule is defined in a +1/+2 timezone). A plain start <= value < stop
+            # test fails for that case, so handle the wrap explicitly.
+            if date_composition_start_comp <= date_composition_stop_comp:
+                return date_composition_start_comp <= value < date_composition_stop_comp
+            return value >= date_composition_start_comp or value < date_composition_stop_comp
 
-        if extended_stop_comp < date_composition_stop_comp and extended_stop_comp >= date_composition_start_comp:
-            skip_stop = True
+        skip_start = _within_operational_hours(extended_start_comp)
+        skip_stop = _within_operational_hours(extended_stop_comp)
 
     return (extended_start_cron, extended_stop_cron, skip_start, skip_stop)

--- a/scheduler/scheduler/cron_helper.py
+++ b/scheduler/scheduler/cron_helper.py
@@ -32,8 +32,13 @@ def extend_windows(
     start_resources_at: str,
     stop_resources_at: str,
     timezone: str,
+    now: datetime | None = None,
 ) -> Tuple[str, str, bool, bool]:
-    now = datetime.now(UTC)
+    # `now` is injectable so callers (and tests) can pin the reference instant.
+    # This matters because converting operational hours from a DST-aware timezone
+    # to UTC depends on whether the reference date falls in summer or winter time.
+    if now is None:
+        now = datetime.now(UTC)
 
     cron_expressions = window_expression_to_cron_expressions(aws_window_expression)
     cron_start = AWSCron(cron_expressions[0])

--- a/scheduler/tests/test_cron_helper.py
+++ b/scheduler/tests/test_cron_helper.py
@@ -26,7 +26,7 @@ def test_skips_window_full_if_within_operational_hours():
     out = extend_windows('Thu:10:00-Thu:11:00', 15, '0 9 ? * * *', '0 18 ? * * *', 'Europe/Amsterdam')
     assert out == ('45 9 ? * THU *', '15 11 ? * THU *', True, True)
 
- def test_skips_bracketing_when_operational_window_wraps_midnight():
+def test_skips_bracketing_when_operational_window_wraps_midnight():
     # Up 00:30-19:00 Europe/Amsterdam => 22:30-17:00 UTC (wraps midnight).
     # A 06:00-08:00 UTC backup window is fully inside operational hours,
     # so both start and stop brackets must be skipped.

--- a/scheduler/tests/test_cron_helper.py
+++ b/scheduler/tests/test_cron_helper.py
@@ -1,37 +1,64 @@
+from datetime import datetime, UTC
+
 from scheduler.cron_helper import extend_windows
 from scheduler.scheduler import handler
 
+# Pin the reference instant so results are deterministic regardless of when CI
+# runs. Converting Europe/Amsterdam operational hours to UTC shifts by an hour
+# between winter (UTC+1) and summer (UTC+2), which moves window edges across the
+# operational-hours boundary. Each DST season is asserted explicitly below.
+NOW_WINTER = datetime(2026, 1, 15, 12, 0, tzinfo=UTC)
+NOW_SUMMER = datetime(2026, 6, 15, 12, 0, tzinfo=UTC)
+
 
 def test_can_extend_windows_from_aws_window_without_wday():
-    out = extend_windows('04:00-05:15', 15, 'on-demand', '0 18 ? * * *', 'Europe/Amsterdam')
+    out = extend_windows('04:00-05:15', 15, 'on-demand', '0 18 ? * * *', 'Europe/Amsterdam', now=NOW_WINTER)
     assert out == ('45 3 ? * * *', '30 5 ? * * *', False, False)
 
 
 def test_can_extend_windows_from_aws_window_with_wday():
-    out = extend_windows('Thu:00:00-Thu:02:00', 15, '0 9 ? * * *', '0 18 ? * * *', 'Europe/Amsterdam')
+    out = extend_windows('Thu:00:00-Thu:02:00', 15, '0 9 ? * * *', '0 18 ? * * *', 'Europe/Amsterdam', now=NOW_WINTER)
     assert out == ('45 23 ? * WED *', '15 2 ? * THU *', False, False)
 
 
 def test_skips_window_start_if_within_operational_hours():
-    out = extend_windows('Thu:17:30-Thu:18:30', 15, '0 11 ? * * *', '0 19 ? * * *', 'Europe/Amsterdam')
+    # Winter: 11:00-19:00 Amsterdam => 10:00-18:00 UTC. Extended start 17:15 UTC
+    # falls inside operational hours, so the start bracket is skipped.
+    out = extend_windows('Thu:17:30-Thu:18:30', 15, '0 11 ? * * *', '0 19 ? * * *', 'Europe/Amsterdam', now=NOW_WINTER)
     assert out == ('15 17 ? * THU *', '45 18 ? * THU *', True, False)
 
 
+def test_skips_window_start_in_summer_dst():
+    # Summer: 11:00-19:00 Amsterdam => 09:00-17:00 UTC. Extended start 17:15 UTC
+    # now falls outside operational hours, so neither bracket is skipped.
+    out = extend_windows('Thu:17:30-Thu:18:30', 15, '0 11 ? * * *', '0 19 ? * * *', 'Europe/Amsterdam', now=NOW_SUMMER)
+    assert out == ('15 17 ? * THU *', '45 18 ? * THU *', False, False)
+
+
 def test_skips_window_stop_if_within_operational_hours():
-    out = extend_windows('Thu:08:30-Thu:09:30', 15, '0 10 ? * * *', '0 20 ? * * *', 'Europe/Amsterdam')
+    # Winter: 10:00-20:00 Amsterdam => 09:00-19:00 UTC. Extended stop 09:45 UTC
+    # falls inside operational hours, so the stop bracket is skipped.
+    out = extend_windows('Thu:08:30-Thu:09:30', 15, '0 10 ? * * *', '0 20 ? * * *', 'Europe/Amsterdam', now=NOW_WINTER)
     assert out == ('15 8 ? * THU *', '45 9 ? * THU *', False, True)
 
 
+def test_skips_window_stop_in_summer_dst():
+    # Summer: 10:00-20:00 Amsterdam => 08:00-18:00 UTC. Both extended start 08:15
+    # and stop 09:45 UTC fall inside operational hours, so both are skipped.
+    out = extend_windows('Thu:08:30-Thu:09:30', 15, '0 10 ? * * *', '0 20 ? * * *', 'Europe/Amsterdam', now=NOW_SUMMER)
+    assert out == ('15 8 ? * THU *', '45 9 ? * THU *', True, True)
+
+
 def test_skips_window_full_if_within_operational_hours():
-    out = extend_windows('Thu:10:00-Thu:11:00', 15, '0 9 ? * * *', '0 18 ? * * *', 'Europe/Amsterdam')
+    out = extend_windows('Thu:10:00-Thu:11:00', 15, '0 9 ? * * *', '0 18 ? * * *', 'Europe/Amsterdam', now=NOW_WINTER)
     assert out == ('45 9 ? * THU *', '15 11 ? * THU *', True, True)
 
 
 def test_skips_bracketing_when_operational_window_wraps_midnight():
-    # Up 00:30-19:00 Europe/Amsterdam => 22:30-17:00 UTC (wraps midnight).
+    # Up 00:30-19:00 Europe/Amsterdam => 23:30-18:00 UTC in winter (wraps midnight).
     # A 06:00-08:00 UTC backup window is fully inside operational hours,
     # so both start and stop brackets must be skipped.
-    out = extend_windows('06:00-08:00', 15, '30 0 ? * * *', '0 19 ? * * *', 'Europe/Amsterdam')
+    out = extend_windows('06:00-08:00', 15, '30 0 ? * * *', '0 19 ? * * *', 'Europe/Amsterdam', now=NOW_WINTER)
     assert out == ('45 5 ? * * *', '15 8 ? * * *', True, True)
 
 

--- a/scheduler/tests/test_cron_helper.py
+++ b/scheduler/tests/test_cron_helper.py
@@ -26,6 +26,12 @@ def test_skips_window_full_if_within_operational_hours():
     out = extend_windows('Thu:10:00-Thu:11:00', 15, '0 9 ? * * *', '0 18 ? * * *', 'Europe/Amsterdam')
     assert out == ('45 9 ? * THU *', '15 11 ? * THU *', True, True)
 
+ def test_skips_bracketing_when_operational_window_wraps_midnight():
+    # Up 00:30-19:00 Europe/Amsterdam => 22:30-17:00 UTC (wraps midnight).
+    # A 06:00-08:00 UTC backup window is fully inside operational hours,
+    # so both start and stop brackets must be skipped.
+    out = extend_windows('06:00-08:00', 15, '30 0 ? * * *', '0 19 ? * * *', 'Europe/Amsterdam')
+    assert out == ('45 5 ? * * *', '15 8 ? * * *', True, True)
 
 def test_scheduler_cron_helper_extend_windows(lambda_context):
     payload = {

--- a/scheduler/tests/test_cron_helper.py
+++ b/scheduler/tests/test_cron_helper.py
@@ -26,12 +26,14 @@ def test_skips_window_full_if_within_operational_hours():
     out = extend_windows('Thu:10:00-Thu:11:00', 15, '0 9 ? * * *', '0 18 ? * * *', 'Europe/Amsterdam')
     assert out == ('45 9 ? * THU *', '15 11 ? * THU *', True, True)
 
+
 def test_skips_bracketing_when_operational_window_wraps_midnight():
     # Up 00:30-19:00 Europe/Amsterdam => 22:30-17:00 UTC (wraps midnight).
     # A 06:00-08:00 UTC backup window is fully inside operational hours,
     # so both start and stop brackets must be skipped.
     out = extend_windows('06:00-08:00', 15, '30 0 ? * * *', '0 19 ? * * *', 'Europe/Amsterdam')
     assert out == ('45 5 ? * * *', '15 8 ? * * *', True, True)
+
 
 def test_scheduler_cron_helper_extend_windows(lambda_context):
     payload = {


### PR DESCRIPTION
## :hammer_and_wrench: Summary

```
if extended_start_comp >= date_composition_start_comp and extended_start_comp < date_composition_stop_comp:
      skip_start = True
  if extended_stop_comp < date_composition_stop_comp and extended_stop_comp >= date_composition_start_comp:
      skip_stop = True
```

  These compare integer HHMM values and assume the operational window sits within a single day (start < stop). For our env, the window is defined in Europe/Amsterdam but RDS windows are UTC, so once converted:

  - up = 00:30→19:00 Amsterdam = 22:30 → 17:00 UTC → start_comp = 2230, stop_comp = 1700

  The window wraps midnight, so start_comp > stop_comp. The >= start AND < stop test can then never be true (no number is both ≥ 2230 and < 1700). So skip_start/skip_stop are always False, every bookend is ENABLED, and the stop fires
  mid-day 

## :rocket: Motivation
- Issue with downtime window at GMT ACC Masterdata Environment (A report was found that RDS was stopped and it stayed that way during work hours as well) 


<!-- Why is this change required? What problem does it solve? -->

## :pencil: Additional Information

A change of logic of when and how downtime windows and backup windows are seen to avoid accidental downtime due to resource scheduler. 
